### PR TITLE
Add webview to the main page

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -179,6 +179,7 @@ android {
 }
 
 dependencies {
+    implementation project(':react-native-webview')
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation "com.facebook.react:react-native:+"  // From node_modules
     implementation project(':@mauron85_react-native-background-geolocation')

--- a/android/app/src/main/java/com/tripleblind/MainApplication.java
+++ b/android/app/src/main/java/com/tripleblind/MainApplication.java
@@ -4,6 +4,7 @@ import android.app.Application;
 import android.content.Context;
 import com.facebook.react.PackageList;
 import com.facebook.react.ReactApplication;
+import com.reactnativecommunity.webview.RNCWebViewPackage;
 import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
 import com.facebook.soloader.SoLoader;

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,4 +1,6 @@
 rootProject.name = 'tripleblind'
+include ':react-native-webview'
+project(':react-native-webview').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-webview/android')
 include ':@mauron85_react-native-background-geolocation-common'
 project(':@mauron85_react-native-background-geolocation-common').projectDir = new File(rootProject.projectDir, '../node_modules/@mauron85/react-native-background-geolocation/android/common')
 include ':@mauron85_react-native-background-geolocation'

--- a/app/views/LocationTracking.js
+++ b/app/views/LocationTracking.js
@@ -8,6 +8,7 @@ import {
   Alert,
   Button
 } from 'react-native';
+import { WebView } from 'react-native-webview';
 
 import BackgroundGeolocation from '@mauron85/react-native-background-geolocation';
 
@@ -167,8 +168,13 @@ class LocationTracking extends Component {
                       <Text style={{width: 50, marginTop: -30, marginRight: 15, padding: 10,textAlign: 'center',alignSelf: 'flex-end', backgroundColor: 'green'}}>Low</Text>
                     </View>
                     <View>
-                      <Text style={styles.sectionDescription, {marginLeft: 35}}>News: N/A</Text>
+                      <Text style={styles.sectionDescription, {fontSize: 18, marginLeft: 5, marginTop: 10}}>Latest News:</Text>
                     </View>
+                    <WebView
+                        source={{ uri: 'https://www.who.int/emergencies/diseases/novel-coronavirus-2019/advice-for-public' }}
+                        style={{ margin
+                            : 10, height: 450 }}
+                    />
                     <View style={{marginTop:25}}>
                       <Button title={"Opt Out"} onPress={() => this.optOut()} />
                     </View>

--- a/app/views/Welcome.js
+++ b/app/views/Welcome.js
@@ -42,14 +42,14 @@ class Welcome extends Component {
                     contentInsetAdjustmentBehavior="automatic"
                     style={styles.scrollView}>
                         <View>
-                            <Text style={styles.sectionContainer, { textAlign: 'center', paddingTop: 15 }}>Safe Passage</Text>
+                            <Text style={styles.sectionContainer, { textAlign: 'center', fontWeight: "bold", fontSize: 24, paddingTop: 15 }}>Safe Paths</Text>
                             <Text style={styles.sectionDescription, { textAlign: 'center', paddingTop: 15 }}>This application will automatically remember your path.  Periodically it will encrpyt and upload your path information.  Then, compare it to the paths of known infections.  If your path crosses with anyone who reports sick, you will be promptly notified.</Text>
                             <Text style={styles.sectionDescription, { textAlign: 'center', paddingTop: 15 }}>Using it is easy, just click the "I Want to Participate" button below.  That's all you need to do, we do the hard work in the background.</Text>
-                            <Text style={styles.sectionDescription, { textAlign: 'center', paddingTop: 15, paddingBottom: 15}}>Please, share this application with friends and family.  Working together we can keep everyone safe.</Text>
+                            <Text style={styles.sectionDescription, { textAlign: 'center', paddingTop: 15, paddingBottom: 75}}>Please, share this application with friends and family.  Working together we can keep everyone safe.</Text>
                             <Button
                                 title="I Want to Participate!"
                                 onPress={() => this.willParticipate()} />
-                            <Text style={styles.sectionDescription, { textAlign: 'center', paddingTop: 15 }}>Brought to you by TripleBlind and the Massachusetts Institute of Technology - MIT</Text>
+                            <Text style={styles.sectionDescription, { textAlign: 'center', paddingTop: 15 }}>Brought to you by the Massachusetts Institute of Technology and TripleBlind</Text>
                         </View>
                 </ScrollView>
             </SafeAreaView>

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -34,6 +34,8 @@ target 'tripleblind' do
   pod 'glog', :podspec => '../node_modules/react-native/third-party-podspecs/glog.podspec'
   pod 'Folly', :podspec => '../node_modules/react-native/third-party-podspecs/Folly.podspec'
 
+  pod 'react-native-webview', :path => '../node_modules/react-native-webview'
+
   target 'tripleblindTests' do
     inherit! :search_paths
     # Pods for testing

--- a/package.json
+++ b/package.json
@@ -11,15 +11,16 @@
   },
   "dependencies": {
     "@mauron85/react-native-background-geolocation": "0.6.2",
+    "@react-native-community/masked-view": "0.1.5",
+    "@react-navigation/native": "5.0.9",
+    "@react-navigation/stack": "5.1.1",
+    "lodash": "4.17.15",
     "react": "16.9.0",
     "react-native": "0.61.5",
-    "@react-navigation/native": "5.0.9",
-    "@react-navigation/stack":"5.1.1",
-    "@react-native-community/masked-view": "0.1.5",
-    "react-native-safe-area-context": "0.6.0",
     "react-native-gesture-handler": "~1.5.0",
+    "react-native-safe-area-context": "0.6.0",
     "react-native-screens": "2.0.0-alpha.12",
-    "lodash":"4.17.15"
+    "react-native-webview": "^8.1.2"
   },
   "devDependencies": {
     "@babel/core": "^7.8.6",


### PR DESCRIPTION
The main page now contains a webview.  Initially it is pointing to a WHO
website with info on the Coronavirus.

Also tweaked the appearance of a few things:
* Changed the title on the welcome page to "Safe Paths" and made more bold
* Added some spacing after the welcome text
* Reworded the "brought to you by" message

 ### Testing Notes ###

Build and visit the mainpage.  You should see the WHO website and be able
to interact with it.


 ### Fixed Issues ###

Resolves issue #3


 ### Environment Notes ###

Adds the standard 'react-native-webview' as a dependency.