### PR TITLE
Altering text on welcome and location tracking pages

### DIFF
--- a/app/views/LocationTracking.js
+++ b/app/views/LocationTracking.js
@@ -168,16 +168,19 @@ class LocationTracking extends Component {
                       <Text style={{width: 50, marginTop: -30, marginRight: 15, padding: 10,textAlign: 'center',alignSelf: 'flex-end', backgroundColor: 'green'}}>Low</Text>
                     </View>
                     <View>
+                      <Text style={styles.sectionDescription, { textAlign: 'center', paddingTop: 10}}>This app is storing your location roughly every five minutes on your phone and no location data has been uploaded or shared with anyone.</Text>
                       <Text style={styles.sectionDescription, {fontSize: 18, marginLeft: 5, marginTop: 10}}>Latest News:</Text>
                     </View>
                     <WebView
                         source={{ uri: 'https://www.who.int/emergencies/diseases/novel-coronavirus-2019/advice-for-public' }}
                         style={{ margin
-                            : 10, height: 450 }}
+                            : 10, height: 380 }}
                     />
                     <View style={{marginTop:25}}>
                       <Button title={"Opt Out"} onPress={() => this.optOut()} />
                     </View>
+                    <Text style={styles.sectionDescription, { textAlign: 'center', paddingTop: 15 }}>Please follow the MIT page below for details</Text>
+                    <Text style={styles.sectionDescription, { color: 'blue', textAlign: 'center', paddingTop: 5 }} onPress={() => Linking.openURL('safepaths.mit.edu')}>safepaths.mit.edu</Text>
                 </ScrollView>
             </SafeAreaView>
             </>

--- a/app/views/Welcome.js
+++ b/app/views/Welcome.js
@@ -43,13 +43,12 @@ class Welcome extends Component {
                     style={styles.scrollView}>
                         <View>
                             <Text style={styles.sectionContainer, { textAlign: 'center', fontWeight: "bold", fontSize: 24, paddingTop: 15 }}>Safe Paths</Text>
-                            <Text style={styles.sectionDescription, { textAlign: 'center', paddingTop: 15 }}>This application will automatically remember your path.  Periodically it will encrpyt and upload your path information.  Then, compare it to the paths of known infections.  If your path crosses with anyone who reports sick, you will be promptly notified.</Text>
-                            <Text style={styles.sectionDescription, { textAlign: 'center', paddingTop: 15 }}>Using it is easy, just click the "I Want to Participate" button below.  That's all you need to do, we do the hard work in the background.</Text>
-                            <Text style={styles.sectionDescription, { textAlign: 'center', paddingTop: 15, paddingBottom: 75}}>Please, share this application with friends and family.  Working together we can keep everyone safe.</Text>
+                            <Text style={styles.sectionDescription, { textAlign: 'center', paddingTop: 15 , paddingBottom: 15 }}>This app will store your location roughly every five minutes on your phone and no location data is uploaded or shared with anyone.</Text>
                             <Button
-                                title="I Want to Participate!"
+                                title="Authorize Location Permission (Even while not using the app/all the time)"
                                 onPress={() => this.willParticipate()} />
-                            <Text style={styles.sectionDescription, { textAlign: 'center', paddingTop: 15 }}>Brought to you by the Massachusetts Institute of Technology and TripleBlind</Text>
+                            <Text style={styles.sectionDescription, { textAlign: 'center', paddingTop: 15 }}>Please follow the MIT page below for details</Text>
+                            <Text style={styles.sectionDescription, { color: 'blue', textAlign: 'center', paddingTop: 15 }} onPress={() => Linking.openURL('safepaths.mit.edu')}>safepaths.mit.edu</Text>
                         </View>
                 </ScrollView>
             </SafeAreaView>


### PR DESCRIPTION
![89341489_643142213178358_8949741293924253696_n](https://user-images.githubusercontent.com/25803433/76185537-d3da0400-61a5-11ea-92c2-dc8e2fd1a31f.jpg)

Following the changes shown in the picture. Was this the original intent? There were a couple of paragraphs that got deleted. One of them encouraged users to get friends and family to download.